### PR TITLE
Implement CRUD logic for backend services

### DIFF
--- a/src/main/app.module.ts
+++ b/src/main/app.module.ts
@@ -6,7 +6,6 @@ import { ProductosModule } from './productos/productos.module';
 import { ClientesModule } from './clientes/clientes.module';
 import { VentasModule } from './ventas/ventas.module';
 import { VentaDetalleModule } from './venta-detalle/venta-detalle.module';
-import { MetodosPagoModule } from './metodos-pago/metodos-pago.module';
 import { ItemVentaModule } from './item-venta/item-venta.module';
 import { MetodoPagoModule } from './metodo-pago/metodo-pago.module';
 import { VentaPagosModule } from './venta-pagos/venta-pagos.module';
@@ -24,7 +23,6 @@ import { VentaPagosModule } from './venta-pagos/venta-pagos.module';
     ClientesModule,
     VentasModule,
     VentaDetalleModule,
-    MetodosPagoModule,
     ItemVentaModule,
     MetodoPagoModule,
     VentaPagosModule,

--- a/src/main/clientes/clientes.module.ts
+++ b/src/main/clientes/clientes.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClientesService } from './clientes.service';
 import { ClientesController } from './clientes.controller';
+import { Cliente } from './entities/cliente.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Cliente])],
   controllers: [ClientesController],
   providers: [ClientesService],
 })

--- a/src/main/clientes/clientes.service.ts
+++ b/src/main/clientes/clientes.service.ts
@@ -1,26 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateClienteDto } from './dto/create-cliente.dto';
 import { UpdateClienteDto } from './dto/update-cliente.dto';
+import { Cliente } from './entities/cliente.entity';
 
 @Injectable()
 export class ClientesService {
+  constructor(
+    @InjectRepository(Cliente)
+    private readonly repo: Repository<Cliente>,
+  ) {}
+
   create(createClienteDto: CreateClienteDto) {
-    return 'This action adds a new cliente';
+    const cliente = this.repo.create(createClienteDto);
+    return this.repo.save(cliente);
   }
 
   findAll() {
-    return `This action returns all clientes`;
+    return this.repo.find();
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} cliente`;
+    return this.repo.findOne({ where: { id } });
   }
 
-  update(id: number, updateClienteDto: UpdateClienteDto) {
-    return `This action updates a #${id} cliente`;
+  async update(id: number, updateClienteDto: UpdateClienteDto) {
+    await this.repo.update(id, updateClienteDto);
+    return this.findOne(id);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} cliente`;
+  async remove(id: number) {
+    await this.repo.delete(id);
+    return { deleted: true };
   }
 }

--- a/src/main/item-venta/item-venta.module.ts
+++ b/src/main/item-venta/item-venta.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ItemVentaService } from './item-venta.service';
 import { ItemVentaController } from './item-venta.controller';
+import { ItemVenta } from './entities/item-venta.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([ItemVenta])],
   controllers: [ItemVentaController],
   providers: [ItemVentaService],
 })

--- a/src/main/item-venta/item-venta.service.ts
+++ b/src/main/item-venta/item-venta.service.ts
@@ -1,26 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateItemVentaDto } from './dto/create-item-venta.dto';
 import { UpdateItemVentaDto } from './dto/update-item-venta.dto';
+import { ItemVenta } from './entities/item-venta.entity';
 
 @Injectable()
 export class ItemVentaService {
+  constructor(
+    @InjectRepository(ItemVenta)
+    private readonly repo: Repository<ItemVenta>,
+  ) {}
+
   create(createItemVentaDto: CreateItemVentaDto) {
-    return 'This action adds a new itemVenta';
+    const item = this.repo.create(createItemVentaDto);
+    return this.repo.save(item);
   }
 
   findAll() {
-    return `This action returns all itemVenta`;
+    return this.repo.find();
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} itemVenta`;
+    return this.repo.findOne({ where: { id } });
   }
 
-  update(id: number, updateItemVentaDto: UpdateItemVentaDto) {
-    return `This action updates a #${id} itemVenta`;
+  async update(id: number, updateItemVentaDto: UpdateItemVentaDto) {
+    await this.repo.update(id, updateItemVentaDto);
+    return this.findOne(id);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} itemVenta`;
+  async remove(id: number) {
+    await this.repo.delete(id);
+    return { deleted: true };
   }
 }

--- a/src/main/metodo-pago/metodo-pago.module.ts
+++ b/src/main/metodo-pago/metodo-pago.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MetodoPagoService } from './metodo-pago.service';
 import { MetodoPagoController } from './metodo-pago.controller';
+import { MetodoPago } from './entities/metodo-pago.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([MetodoPago])],
   controllers: [MetodoPagoController],
   providers: [MetodoPagoService],
 })

--- a/src/main/metodo-pago/metodo-pago.service.ts
+++ b/src/main/metodo-pago/metodo-pago.service.ts
@@ -1,26 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateMetodoPagoDto } from './dto/create-metodo-pago.dto';
 import { UpdateMetodoPagoDto } from './dto/update-metodo-pago.dto';
+import { MetodoPago } from './entities/metodo-pago.entity';
 
 @Injectable()
 export class MetodoPagoService {
+  constructor(
+    @InjectRepository(MetodoPago)
+    private readonly repo: Repository<MetodoPago>,
+  ) {}
+
   create(createMetodoPagoDto: CreateMetodoPagoDto) {
-    return 'This action adds a new metodoPago';
+    const metodo = this.repo.create(createMetodoPagoDto);
+    return this.repo.save(metodo);
   }
 
   findAll() {
-    return `This action returns all metodoPago`;
+    return this.repo.find();
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} metodoPago`;
+    return this.repo.findOne({ where: { id } });
   }
 
-  update(id: number, updateMetodoPagoDto: UpdateMetodoPagoDto) {
-    return `This action updates a #${id} metodoPago`;
+  async update(id: number, updateMetodoPagoDto: UpdateMetodoPagoDto) {
+    await this.repo.update(id, updateMetodoPagoDto);
+    return this.findOne(id);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} metodoPago`;
+  async remove(id: number) {
+    await this.repo.delete(id);
+    return { deleted: true };
   }
 }

--- a/src/main/productos/productos.module.ts
+++ b/src/main/productos/productos.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProductosService } from './productos.service';
 import { ProductosController } from './productos.controller';
+import { Producto } from './entities/producto.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Producto])],
   controllers: [ProductosController],
   providers: [ProductosService],
 })

--- a/src/main/productos/productos.service.ts
+++ b/src/main/productos/productos.service.ts
@@ -1,26 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateProductoDto } from './dto/create-producto.dto';
 import { UpdateProductoDto } from './dto/update-producto.dto';
+import { Producto } from './entities/producto.entity';
 
 @Injectable()
 export class ProductosService {
+  constructor(
+    @InjectRepository(Producto)
+    private readonly repo: Repository<Producto>,
+  ) {}
+
   create(createProductoDto: CreateProductoDto) {
-    return 'This action adds a new producto';
+    const producto = this.repo.create(createProductoDto);
+    return this.repo.save(producto);
   }
 
   findAll() {
-    return `This action returns all productos`;
+    return this.repo.find();
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} producto`;
+    return this.repo.findOne({ where: { id } });
   }
 
-  update(id: number, updateProductoDto: UpdateProductoDto) {
-    return `This action updates a #${id} producto`;
+  async update(id: number, updateProductoDto: UpdateProductoDto) {
+    await this.repo.update(id, updateProductoDto);
+    return this.findOne(id);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} producto`;
+  async remove(id: number) {
+    await this.repo.delete(id);
+    return { deleted: true };
   }
 }

--- a/src/main/venta-detalle/venta-detalle.module.ts
+++ b/src/main/venta-detalle/venta-detalle.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { VentaDetalleService } from './venta-detalle.service';
 import { VentaDetalleController } from './venta-detalle.controller';
+import { VentaDetalle } from './entities/venta-detalle.entity';
+import { ItemVenta } from '../item-venta/entities/item-venta.entity';
+import { Producto } from '../productos/entities/producto.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([VentaDetalle, ItemVenta, Producto])],
   controllers: [VentaDetalleController],
   providers: [VentaDetalleService],
 })

--- a/src/main/venta-pagos/venta-pagos.module.ts
+++ b/src/main/venta-pagos/venta-pagos.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { VentaPagosService } from './venta-pagos.service';
 import { VentaPagosController } from './venta-pagos.controller';
+import { VentaPago } from './entities/venta-pago.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([VentaPago])],
   controllers: [VentaPagosController],
   providers: [VentaPagosService],
 })

--- a/src/main/ventas/ventas.module.ts
+++ b/src/main/ventas/ventas.module.ts
@@ -1,8 +1,27 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { VentasService } from './ventas.service';
 import { VentasController } from './ventas.controller';
+import { Venta } from './entities/venta.entity';
+import { Cliente } from '../clientes/entities/cliente.entity';
+import { Producto } from '../productos/entities/producto.entity';
+import { ItemVenta } from '../item-venta/entities/item-venta.entity';
+import { VentaDetalle } from '../venta-detalle/entities/venta-detalle.entity';
+import { MetodoPago } from '../metodo-pago/entities/metodo-pago.entity';
+import { VentaPago } from '../venta-pagos/entities/venta-pago.entity';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Venta,
+      Cliente,
+      Producto,
+      ItemVenta,
+      VentaDetalle,
+      MetodoPago,
+      VentaPago,
+    ]),
+  ],
   controllers: [VentasController],
   providers: [VentasService],
 })

--- a/src/main/ventas/ventas.service.ts
+++ b/src/main/ventas/ventas.service.ts
@@ -1,26 +1,103 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateVentaDto } from './dto/create-venta.dto';
 import { UpdateVentaDto } from './dto/update-venta.dto';
+import { Venta } from './entities/venta.entity';
+import { Cliente } from '../clientes/entities/cliente.entity';
+import { Producto } from '../productos/entities/producto.entity';
+import { ItemVenta } from '../item-venta/entities/item-venta.entity';
+import { VentaDetalle } from '../venta-detalle/entities/venta-detalle.entity';
+import { MetodoPago } from '../metodo-pago/entities/metodo-pago.entity';
+import { VentaPago } from '../venta-pagos/entities/venta-pago.entity';
 
 @Injectable()
 export class VentasService {
-  create(createVentaDto: CreateVentaDto) {
-    return 'This action adds a new venta';
+  constructor(
+    @InjectRepository(Venta)
+    private readonly repo: Repository<Venta>,
+    @InjectRepository(Cliente)
+    private readonly clienteRepo: Repository<Cliente>,
+    @InjectRepository(Producto)
+    private readonly productoRepo: Repository<Producto>,
+    @InjectRepository(ItemVenta)
+    private readonly itemRepo: Repository<ItemVenta>,
+    @InjectRepository(VentaDetalle)
+    private readonly detalleRepo: Repository<VentaDetalle>,
+    @InjectRepository(MetodoPago)
+    private readonly metodoRepo: Repository<MetodoPago>,
+    @InjectRepository(VentaPago)
+    private readonly pagoRepo: Repository<VentaPago>,
+  ) {}
+
+  async create(createVentaDto: CreateVentaDto) {
+    const cliente = await this.clienteRepo.findOne({
+      where: { id: createVentaDto.clienteId },
+    });
+    if (!cliente) throw new Error('Cliente no encontrado');
+
+    const venta = this.repo.create({ cliente });
+
+    venta.detalles = [];
+    for (const detDto of createVentaDto.detalles) {
+      const producto = await this.productoRepo.findOne({
+        where: { id: detDto.productoId },
+      });
+      if (!producto) throw new Error('Producto no encontrado');
+      const item = this.itemRepo.create({
+        nombre: producto.nombre,
+        descripcion: producto.descripcion,
+        precio: producto.precio,
+      });
+      await this.itemRepo.save(item);
+      const detalle = this.detalleRepo.create({
+        item,
+        cantidad: detDto.cantidad,
+      });
+      venta.detalles.push(detalle);
+    }
+
+    venta.pagos = [];
+    for (const pagoDto of createVentaDto.pagos) {
+      const metodo = await this.metodoRepo.findOne({
+        where: { id: pagoDto.metodoId },
+      });
+      if (!metodo) throw new Error('Método de pago no encontrado');
+      const pago = this.pagoRepo.create({
+        metodo,
+        monto: pagoDto.monto,
+        cuotas: pagoDto.cuotas,
+      });
+      venta.pagos.push(pago);
+    }
+
+    return this.repo.save(venta);
   }
 
   findAll() {
-    return `This action returns all ventas`;
+    return this.repo.find();
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} venta`;
+    return this.repo.findOne({ where: { id } });
   }
 
-  update(id: number, updateVentaDto: UpdateVentaDto) {
-    return `This action updates a #${id} venta`;
+  async update(id: number, updateVentaDto: UpdateVentaDto) {
+    const venta = await this.repo.findOne({ where: { id } });
+    if (!venta) throw new Error('Venta no encontrada');
+
+    if (updateVentaDto.clienteId) {
+      const cliente = await this.clienteRepo.findOne({
+        where: { id: updateVentaDto.clienteId },
+      });
+      if (cliente) venta.cliente = cliente;
+    }
+
+    return this.repo.save(venta);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} venta`;
+  async remove(id: number) {
+    await this.repo.delete(id);
+    return { deleted: true };
   }
 }


### PR DESCRIPTION
## Summary
- add TypeORM imports for all modules
- implement repositories in backend services for CRUD operations
- remove unused MetodosPagoModule import

## Testing
- `npm run build:nest`

------
https://chatgpt.com/codex/tasks/task_e_687675a4e1608333a57bf7f810a98b0c