### PR TITLE
Add CRUD UI pages

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,10 @@ import Panel from "./components/Panel";
 import Navbar from "./layout/Navbar";
 import { Routes, Route } from "react-router-dom";
 import PageHome from "./pages/PageHome";
+import PageClientes from "./pages/PageClientes";
+import PageProductos from "./pages/PageProductos";
+import PageMetodoPago from "./pages/PageMetodoPago";
+import PageItemVenta from "./pages/PageItemVenta";
 
 export default function App() {
   
@@ -10,8 +14,11 @@ export default function App() {
       <Navbar />
       <Panel>
         <Routes>
-          <Route path="/" element={
-            <PageHome />} />
+          <Route path="/" element={<PageHome />} />
+          <Route path="/clientes" element={<PageClientes />} />
+          <Route path="/productos" element={<PageProductos />} />
+          <Route path="/metodos-pago" element={<PageMetodoPago />} />
+          <Route path="/items-venta" element={<PageItemVenta />} />
         </Routes>
       </Panel>
     </div>

--- a/src/renderer/api/crud.ts
+++ b/src/renderer/api/crud.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const BASE_URL = 'http://localhost:3000/api';
+
+export async function getAll(entity: string) {
+  const { data } = await axios.get(`${BASE_URL}/${entity}`);
+  return data;
+}
+
+export async function create(entity: string, payload: any) {
+  const { data } = await axios.post(`${BASE_URL}/${entity}`, payload);
+  return data;
+}
+
+export async function update(entity: string, id: number, payload: any) {
+  const { data } = await axios.patch(`${BASE_URL}/${entity}/${id}`, payload);
+  return data;
+}
+
+export async function remove(entity: string, id: number) {
+  const { data } = await axios.delete(`${BASE_URL}/${entity}/${id}`);
+  return data;
+}

--- a/src/renderer/layout/Navbar.jsx
+++ b/src/renderer/layout/Navbar.jsx
@@ -1,6 +1,11 @@
 import {
-  Calendar, Home, PawPrint, User, Users, Menu, X,
-  FileBarChart, Activity
+  Home,
+  Users,
+  Package,
+  CreditCard,
+  ShoppingCart,
+  Menu,
+  X,
 } from 'lucide-react'
 import React, { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
@@ -9,10 +14,10 @@ import logo from '../assets/logo.webp';
 
 const navItems = [
   { name: "Inicio", href: "/", icon: <Home size={20} /> },
-  { name: "Movimientos", href: "/moves", icon: <Activity size={20} /> },
-  { name: "Usuarios", href: "/users", icon: <User size={20} /> },
-  { name: "Cuentas corrientes", href: "/ctas-ctes", icon: <FileBarChart size={20} /> },
-  { name: "Informes", href: "/data", icon: <FileBarChart size={20} /> }
+  { name: "Clientes", href: "/clientes", icon: <Users size={20} /> },
+  { name: "Productos", href: "/productos", icon: <Package size={20} /> },
+  { name: "Métodos de pago", href: "/metodos-pago", icon: <CreditCard size={20} /> },
+  { name: "Items de venta", href: "/items-venta", icon: <ShoppingCart size={20} /> },
 ]
 
 export default function Navbar() {

--- a/src/renderer/pages/CrudPage.tsx
+++ b/src/renderer/pages/CrudPage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import Table from '../layout/Table';
+import DynamicForm from '../layout/DynamicForm';
+import PrimaryButton from '../components/PrimaryButton';
+import SecondaryButton from '../components/SecondaryButton';
+import DangerButton from '../components/DangerButton';
+import { getAll, create, update, remove } from '../api/crud';
+
+interface CrudConfig {
+  entity: string;
+  title: string;
+  columns: (string | { titulo: string; clave: string })[];
+  searchFields: string[];
+  formInputs: any[]; // Input definitions for DynamicForm
+}
+
+export default function CrudPage({ config }: { config: CrudConfig }) {
+  const { entity, title, columns, searchFields, formInputs } = config;
+  const [items, setItems] = useState<any[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [editing, setEditing] = useState<any | null>(null);
+  const [search, setSearch] = useState('');
+
+  const fetchItems = async () => {
+    try {
+      const data = await getAll(entity);
+      setItems(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, []);
+
+  const handleSubmit = async (values: any) => {
+    try {
+      if (editing) {
+        await update(entity, editing.id, values);
+      } else {
+        await create(entity, values);
+      }
+      setEditing(null);
+      setSelected(null);
+      fetchItems();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (selected == null) return;
+    if (!confirm('¿Eliminar registro?')) return;
+    try {
+      await remove(entity, selected);
+      setSelected(null);
+      fetchItems();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const filtered = items.filter(item =>
+    searchFields.some(f => {
+      const value = f.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), item);
+      return String(value ?? '')
+        .toLowerCase()
+        .includes(search.toLowerCase());
+    })
+  );
+
+  const inputs = formInputs.map(input => ({
+    ...input,
+    value: editing ? editing[input.name] ?? '' : undefined,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4 p-2 w-full overflow-auto">
+      <h2 className="text-2xl font-bold">{title}</h2>
+
+      <div className="flex gap-2 items-center">
+        <input
+          className="border rounded px-2 py-1 text-black"
+          placeholder="Buscar..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        {selected != null && (
+          <>
+            <DangerButton title="Eliminar" functionClick={handleDelete} />
+            <SecondaryButton title="Cancelar" functionClick={() => { setSelected(null); setEditing(null); }} />
+          </>
+        )}
+      </div>
+
+      <Table
+        datos={filtered}
+        encabezados={columns}
+        onDobleClickFila={id => {
+          const item = items.find(it => it.id === id);
+          setEditing(item ?? null);
+          setSelected(id);
+        }}
+        onFilaSeleccionada={id => setSelected(id)}
+      />
+
+      <DynamicForm
+        inputs={inputs}
+        onSubmit={handleSubmit}
+        titleBtn={editing ? 'Actualizar' : 'Crear'}
+      />
+    </div>
+  );
+}

--- a/src/renderer/pages/PageClientes.tsx
+++ b/src/renderer/pages/PageClientes.tsx
@@ -1,0 +1,19 @@
+import CrudPage from './CrudPage';
+
+export default function PageClientes() {
+  const config = {
+    entity: 'clientes',
+    title: 'Clientes',
+    columns: ['id', 'nombre', 'apellido', 'email', 'telefono', 'direccion'],
+    searchFields: ['nombre', 'apellido', 'email'],
+    formInputs: [
+      { name: 'nombre', label: 'Nombre', type: 'text', required: true },
+      { name: 'apellido', label: 'Apellido', type: 'text' },
+      { name: 'email', label: 'Email', type: 'email' },
+      { name: 'telefono', label: 'Teléfono', type: 'text' },
+      { name: 'direccion', label: 'Dirección', type: 'text' },
+    ],
+  };
+
+  return <CrudPage config={config} />;
+}

--- a/src/renderer/pages/PageItemVenta.tsx
+++ b/src/renderer/pages/PageItemVenta.tsx
@@ -1,0 +1,18 @@
+import CrudPage from './CrudPage';
+
+export default function PageItemVenta() {
+  const config = {
+    entity: 'item-venta',
+    title: 'Items de Venta',
+    columns: ['id', 'nombre', 'descripcion', 'precio', 'cantidad'],
+    searchFields: ['nombre', 'descripcion'],
+    formInputs: [
+      { name: 'nombre', label: 'Nombre', type: 'text', required: true },
+      { name: 'descripcion', label: 'Descripción', type: 'text' },
+      { name: 'precio', label: 'Precio', type: 'number', required: true },
+      { name: 'cantidad', label: 'Cantidad', type: 'number', required: true },
+    ],
+  };
+
+  return <CrudPage config={config} />;
+}

--- a/src/renderer/pages/PageMetodoPago.tsx
+++ b/src/renderer/pages/PageMetodoPago.tsx
@@ -1,0 +1,16 @@
+import CrudPage from './CrudPage';
+
+export default function PageMetodoPago() {
+  const config = {
+    entity: 'metodo-pago',
+    title: 'Métodos de Pago',
+    columns: ['id', 'nombre', 'descripcion'],
+    searchFields: ['nombre', 'descripcion'],
+    formInputs: [
+      { name: 'nombre', label: 'Nombre', type: 'text', required: true },
+      { name: 'descripcion', label: 'Descripción', type: 'text' },
+    ],
+  };
+
+  return <CrudPage config={config} />;
+}

--- a/src/renderer/pages/PageProductos.tsx
+++ b/src/renderer/pages/PageProductos.tsx
@@ -1,0 +1,19 @@
+import CrudPage from './CrudPage';
+
+export default function PageProductos() {
+  const config = {
+    entity: 'productos',
+    title: 'Productos',
+    columns: ['id', 'nombre', 'descripcion', 'precio', 'stock', 'sku'],
+    searchFields: ['nombre', 'descripcion', 'sku'],
+    formInputs: [
+      { name: 'nombre', label: 'Nombre', type: 'text', required: true },
+      { name: 'descripcion', label: 'Descripción', type: 'text' },
+      { name: 'precio', label: 'Precio', type: 'number', required: true },
+      { name: 'stock', label: 'Stock', type: 'number', required: true },
+      { name: 'sku', label: 'SKU', type: 'text' },
+    ],
+  };
+
+  return <CrudPage config={config} />;
+}


### PR DESCRIPTION
## Summary
- add a generic CRUD page component and API helpers
- expose CRUD pages for clientes, productos, métodos de pago and items de venta
- update navigation and routes

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877cbef61508333a241be6decc9fbf0