### PR TITLE
Fix child window typing in ventas page

### DIFF
--- a/src/renderer/entities/ventas/Page.tsx
+++ b/src/renderer/entities/ventas/Page.tsx
@@ -36,6 +36,7 @@ export default function SalesPage() {
 
     const child = window.open(hashRoute, '_blank', 'noopener,noreferrer')
     if (!child) return
+    const childWindow = child
 
     const origin = window.location.origin
     let intervalId: number | null = null
@@ -49,10 +50,10 @@ export default function SalesPage() {
     }
 
     function handleReady(event: MessageEvent) {
-      if (event.source !== child) return
+      if (event.source !== childWindow) return
       if (event.origin !== origin) return
       if (event.data?.type === 'READY') {
-        child.postMessage({ type: 'INIT_DATA', payload }, origin)
+        childWindow.postMessage({ type: 'INIT_DATA', payload }, origin)
         cleanup()
       }
     }
@@ -60,7 +61,7 @@ export default function SalesPage() {
     window.addEventListener('message', handleReady)
 
     intervalId = window.setInterval(() => {
-      if (child.closed) cleanup()
+      if (childWindow.closed) cleanup()
     }, 500)
   }, [])
 


### PR DESCRIPTION
## Summary
- ensure the ventas child window reference is explicitly typed as Window after the existing null guard
- use the new childWindow reference when posting messages and checking window state

## Testing
- npm run electron:build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dded2b4d708333a6b448e3925e190b